### PR TITLE
Fixed usage of the wrong exception class in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Hence, for instance, you can write the following:
 
     try {
         $manager->bind();
-    } catch (BindingException $e) {
+    } catch (BindException $e) {
         // Do something about it
     }
 


### PR DESCRIPTION
I found the usage of the wrong class name in an example in the documentation/readme-file while I integrated the code in a new application.

The exception class "BindingException" doesn't exist. You have to use the class "BindException".
